### PR TITLE
Do not attempt to disconnect if there's no connection

### DIFF
--- a/rediscluster/client.py
+++ b/rediscluster/client.py
@@ -710,7 +710,8 @@ class RedisCluster(Redis):
                 redirect_addr, asking = "{0}:{1}".format(e.host, e.port), True
             except BaseException as e:
                 log.exception("BaseException")
-                connection.disconnect()
+                if connection is not None:
+                    connection.disconnect()
                 raise e
             finally:
                 if connection is not None:


### PR DESCRIPTION
Duplicate of https://github.com/Grokzen/redis-py-cluster/pull/472

> This is another case of https://github.com/Grokzen/redis-py-cluster/issues/453
> 
> There are cases in which we can get a `BaseException` before we have
established a connection, which means that attempting to disconnect from
it will result in an unhandled exception.